### PR TITLE
MNT: Fix package metadata to correctly identify module

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ classifiers =
 
 [options]
 python_requires = >=3
-pymodules = looseversion.py
+py_modules = looseversion
 
 [options.package_data]
 * = tests.py


### PR DESCRIPTION
Closes #7.