### PR TITLE
FIX: Ignore empty strings in splits

### DIFF
--- a/src/looseversion/__init__.py
+++ b/src/looseversion/__init__.py
@@ -119,7 +119,7 @@ class LooseVersion:
     of "want").
     """
 
-    component_re = re.compile(r"(\d+ | [a-z]+ | \.)", re.VERBOSE)
+    component_re: re.Pattern[str] = re.compile(r"(\d+ | [a-z]+ | \.)", re.VERBOSE)
     vstring: str
     version: list[int | str]
 

--- a/src/looseversion/__init__.py
+++ b/src/looseversion/__init__.py
@@ -163,7 +163,7 @@ class LooseVersion:
         # use by __str__
         self.vstring = vstring
         components: list[str | int] = [
-            x for x in self.component_re.split(vstring) if x != "."
+            x for x in self.component_re.split(vstring) if x and x != "."
         ]
         for i, obj in enumerate(components):
             try:

--- a/src/looseversion/__init__.pyi
+++ b/src/looseversion/__init__.pyi
@@ -2,7 +2,7 @@ from re import Pattern
 from typing import Union
 
 class LooseVersion:
-    component_re: Pattern
+    component_re: Pattern[str]
     vstring: str
     version: Union[str, int]
     def __init__(self, vstring: Union[str, None] = ...) -> None: ...

--- a/tests.py
+++ b/tests.py
@@ -59,5 +59,22 @@ def test_cmp(v1, v2, result):
     assert loosev2._cmp(object()) == NotImplemented
 
 
+@pytest.mark.parametrize('vstring,version',
+    [
+        ('1.5.1', [1, 5, 1]),
+        ('1.5.2b2', [1, 5, 2, 'b', 2]),
+        ('161', [161]),
+        ('3.10a', [3, 10, 'a']),
+        ('1.13++', [1, 13, '++']),
+    ],
+)
+def test_split(vstring, version):
+    # Regression test to ensure we don't accidentally break parsing (again)
+    # This can be changed if the version representation changes
+    v = lv.LooseVersion(vstring)
+    assert v.vstring == vstring
+    assert v.version == version
+
+
 if __name__ == '__main__':
     sys.exit(pytest.main([__file__] + sys.argv[1:]))


### PR DESCRIPTION
Figured issues like this would get caught by the compatibility tests with distutils, but we simply convert the old type to the new, so everything was getting extra empty strings. This adds explicit tests for representations.

Closes #13.