### PR TITLE
ENH: Restore Python 2 semantics

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 ## Releases
 
+### 1.2.0 (Unreleased)
+
+- 2023.05.25
+  - Enable installation on Python 2+
+  - Ensure consistent semantics between Python 2 and 3
+
 ### 1.1.2 (22 Feb 2023)
 
 - 2023.02.22

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
     "License :: OSI Approved :: Python Software Foundation License",
 ]
 urls = {Homepage = "https://github.com/effigies/looseversion"}
-requires-python = ">=3"
 
 [tool.hatch.build]
 exclude = [".github"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "looseversion"
 maintainers = [{name = "Chris Markiewicz", email = "effigies@gmail.com"}]
-version = "1.1.2"
+version = "1.2.0.dev0"
 description = "Version numbering for anarchists and software realists"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/looseversion/__init__.py
+++ b/src/looseversion/__init__.py
@@ -16,8 +16,6 @@ Every version number class implements the following interface:
     of the same class or a string (which will be parsed to an instance
     of the same class, thus must follow the same rules)
 """
-from __future__ import annotations
-
 import re
 import sys
 
@@ -86,8 +84,7 @@ import sys
 # have a conception that matches common notions about version numbers.
 
 
-class LooseVersion:
-
+class LooseVersion(object):
     """Version numbering for anarchists and software realists.
     Implements the standard interface for version number classes as
     described above.  A version number consists of a series of numbers,
@@ -119,52 +116,48 @@ class LooseVersion:
     of "want").
     """
 
-    component_re: re.Pattern[str] = re.compile(r"(\d+ | [a-z]+ | \.)", re.VERBOSE)
-    vstring: str
-    version: list[int | str]
+    component_re = re.compile(r"(\d+ | [a-z]+ | \.)", re.VERBOSE)
 
-    def __init__(self, vstring: str | None = None):
+    def __init__(self, vstring=None):
         if vstring:
             self.parse(vstring)
 
-    def __eq__(self, other: object) -> bool:
+    def __eq__(self, other):
         c = self._cmp(other)
         if c is NotImplemented:
             return NotImplemented
         return c == 0
 
-    def __lt__(self, other: object) -> bool:
+    def __lt__(self, other):
         c = self._cmp(other)
         if c is NotImplemented:
             return NotImplemented
         return c < 0
 
-    def __le__(self, other: object) -> bool:
+    def __le__(self, other):
         c = self._cmp(other)
         if c is NotImplemented:
             return NotImplemented
         return c <= 0
 
-    def __gt__(self, other: object) -> bool:
+    def __gt__(self, other):
         c = self._cmp(other)
         if c is NotImplemented:
             return NotImplemented
         return c > 0
 
-    def __ge__(self, other: object) -> bool:
+    def __ge__(self, other):
         c = self._cmp(other)
         if c is NotImplemented:
             return NotImplemented
         return c >= 0
 
-    def parse(self, vstring: str) -> None:
+    def parse(self, vstring):
         # I've given up on thinking I can reconstruct the version string
         # from the parsed tuple -- so I just store the string here for
         # use by __str__
         self.vstring = vstring
-        components: list[str | int] = [
-            x for x in self.component_re.split(vstring) if x and x != "."
-        ]
+        components = [x for x in self.component_re.split(vstring) if x and x != "."]
         for i, obj in enumerate(components):
             try:
                 components[i] = int(obj)
@@ -173,13 +166,13 @@ class LooseVersion:
 
         self.version = components
 
-    def __str__(self) -> str:
+    def __str__(self):
         return self.vstring
 
-    def __repr__(self) -> str:
+    def __repr__(self):
         return "LooseVersion ('%s')" % str(self)
 
-    def _cmp(self, other: object) -> int:
+    def _cmp(self, other):
         other = self._coerce(other)
         if other is NotImplemented:
             return NotImplemented
@@ -193,7 +186,7 @@ class LooseVersion:
         return NotImplemented
 
     @staticmethod
-    def _coerce(other: object) -> LooseVersion:
+    def _coerce(other):
         if isinstance(other, LooseVersion):
             return other
         elif isinstance(other, str):

--- a/src/looseversion/__init__.py
+++ b/src/looseversion/__init__.py
@@ -84,6 +84,25 @@ import sys
 # have a conception that matches common notions about version numbers.
 
 
+if sys.version_info >= (3,):
+
+    class _Py2Int(int):
+        """Integer object that compares < any string"""
+
+        def __gt__(self, other):
+            if isinstance(other, str):
+                return False
+            return super().__gt__(other)
+
+        def __lt__(self, other):
+            if isinstance(other, str):
+                return True
+            return super().__lt__(other)
+
+else:
+    _Py2Int = int
+
+
 class LooseVersion(object):
     """Version numbering for anarchists and software realists.
     Implements the standard interface for version number classes as
@@ -160,7 +179,7 @@ class LooseVersion(object):
         components = [x for x in self.component_re.split(vstring) if x and x != "."]
         for i, obj in enumerate(components):
             try:
-                components[i] = int(obj)
+                components[i] = _Py2Int(obj)
             except ValueError:
                 pass
 

--- a/src/looseversion/__init__.pyi
+++ b/src/looseversion/__init__.pyi
@@ -1,10 +1,10 @@
 from re import Pattern
-from typing import Union
+from typing import List, Union
 
 class LooseVersion:
     component_re: Pattern[str]
     vstring: str
-    version: Union[str, int]
+    version: List[Union[str, int]]
     def __init__(self, vstring: Union[str, None] = ...) -> None: ...
     def __eq__(self, other: object) -> bool: ...
     def __lt__(self, other: object) -> bool: ...

--- a/tests.py
+++ b/tests.py
@@ -39,15 +39,19 @@ def test_LooseVersion_compat(v1, v2):
 
 
 # Adapted from Cpython:Lib/distutils/tests/test_version.py
-@pytest.mark.parametrize("v1,v2,result",
-    [('1.5.1', '1.5.2b2', -1),
-     ('161', '3.10a', 1),
-     ('8.02', '8.02', 0),
-     ('3.4j', '1996.07.12', -1),
-     ('3.2.pl0', '3.1.1.6', 1),
-     ('2g6', '11g', -1),
-     ('0.960923', '2.2beta29', -1),
-     ('1.13++', '5.5.kw', -1)])
+@pytest.mark.parametrize(
+    "v1,v2,result",
+    [
+        ("1.5.1", "1.5.2b2", -1),
+        ("161", "3.10a", 1),
+        ("8.02", "8.02", 0),
+        ("3.4j", "1996.07.12", -1),
+        ("3.2.pl0", "3.1.1.6", 1),
+        ("2g6", "11g", -1),
+        ("0.960923", "2.2beta29", -1),
+        ("1.13++", "5.5.kw", -1),
+    ],
+)
 def test_cmp(v1, v2, result):
     loosev1 = lv.LooseVersion(v1)
     loosev2 = lv.LooseVersion(v2)
@@ -59,13 +63,14 @@ def test_cmp(v1, v2, result):
     assert loosev2._cmp(object()) == NotImplemented
 
 
-@pytest.mark.parametrize('vstring,version',
+@pytest.mark.parametrize(
+    "vstring,version",
     [
-        ('1.5.1', [1, 5, 1]),
-        ('1.5.2b2', [1, 5, 2, 'b', 2]),
-        ('161', [161]),
-        ('3.10a', [3, 10, 'a']),
-        ('1.13++', [1, 13, '++']),
+        ("1.5.1", [1, 5, 1]),
+        ("1.5.2b2", [1, 5, 2, "b", 2]),
+        ("161", [161]),
+        ("3.10a", [3, 10, "a"]),
+        ("1.13++", [1, 13, "++"]),
     ],
 )
 def test_split(vstring, version):
@@ -76,13 +81,14 @@ def test_split(vstring, version):
     assert v.version == version
 
 
-@pytest.mark.parametrize("v1,v2,result",
+@pytest.mark.parametrize(
+    "v1,v2,result",
     [
-        ('0.3@v0.3', '0.3.1@v0.3.1', 1),
-        ('0.3.1@v0.3.1', '0.3@v0.3', -1),
-        ('13.0-beta3', '13.0.1', 1),
-        ('13.0.1', '13.0-beta3', -1),
-    ]
+        ("0.3@v0.3", "0.3.1@v0.3.1", 1),
+        ("0.3.1@v0.3.1", "0.3@v0.3", -1),
+        ("13.0-beta3", "13.0.1", 1),
+        ("13.0.1", "13.0-beta3", -1),
+    ],
 )
 def test_py2_rules(v1, v2, result):
     """Python 2 did allow strings and numbers to be compared.
@@ -95,5 +101,6 @@ def test_py2_rules(v1, v2, result):
     assert loosev2._cmp(loosev1) == -result
     assert loosev2._cmp(v1) == -result
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     sys.exit(pytest.main([__file__] + sys.argv[1:]))

--- a/tests.py
+++ b/tests.py
@@ -76,5 +76,24 @@ def test_split(vstring, version):
     assert v.version == version
 
 
+@pytest.mark.parametrize("v1,v2,result",
+    [
+        ('0.3@v0.3', '0.3.1@v0.3.1', 1),
+        ('0.3.1@v0.3.1', '0.3@v0.3', -1),
+        ('13.0-beta3', '13.0.1', 1),
+        ('13.0.1', '13.0-beta3', -1),
+    ]
+)
+def test_py2_rules(v1, v2, result):
+    """Python 2 did allow strings and numbers to be compared.
+    Verify consistent, generally unintuitive behavior.
+    """
+    loosev1 = lv.LooseVersion(v1)
+    loosev2 = lv.LooseVersion(v2)
+    assert loosev1._cmp(loosev2) == result
+    assert loosev1._cmp(v2) == result
+    assert loosev2._cmp(loosev1) == -result
+    assert loosev2._cmp(v1) == -result
+
 if __name__ == '__main__':
     sys.exit(pytest.main([__file__] + sys.argv[1:]))


### PR DESCRIPTION
Time was, any `LooseVersion` could be compared to any other `LooseVersion`, and if that meant comparing `int`s and `str`s, so be it. That time was Python 2. Obviously Python 2 is end-of-life, but to verify that the behavior was consistent, I needed get tests working in Python 2. That basically means subclassing `object` and stripping out type annotations, which is fine, since we're publishing a stub anyway.

I'm not going to bother trying to get tox/GitHub actions working with Python 2. This will be installable on end-of-life Pythons, but not supported.

Closes #16.