### PR TITLE
CI: Restore regular pip-installed tox

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -49,8 +49,10 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
         allow-prereleases: true
+    - name: Install tox
+      run: pip install --upgrade pip tox tox-gh-actions
     - name: Test
-      run: pipx run --pip-args "tox-gh-actions" tox
+      run: tox
 
   deploy:
     needs: [build, test]


### PR DESCRIPTION
Just realized tox was running on 3.10 for all jobs. Hope that I didn't accidentally push a package that will fail on 3.12...