### PR TITLE
Run tests on 2.7.

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -7,6 +7,7 @@ on:
   pull_request: {branches: [main]}
   schedule:
     - cron: '0 0 * * MON'
+  workflow_dispatch:
 
 jobs:
   build:
@@ -53,6 +54,18 @@ jobs:
       run: pip install --upgrade pip tox tox-gh-actions
     - name: Test
       run: tox
+
+  test-27:
+    name: Python 2.7 test on ubuntu-20.04
+    runs-on: ubuntu-20.04
+    container:
+      image: python:2.7-buster
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install on 2.7
+      run: pip install --upgrade pip setuptools pytest .
+    - name: Test on 2.7
+      run: pytest tests.py
 
   deploy:
     needs: [build, test]

--- a/tests.py
+++ b/tests.py
@@ -1,3 +1,4 @@
+import operator
 import sys
 import warnings
 
@@ -103,6 +104,35 @@ def test_py2_rules(v1, v2, result):
     assert loosev1._cmp(v2) == result
     assert loosev2._cmp(loosev1) == -result
     assert loosev2._cmp(v1) == -result
+
+
+def test_str():
+    assert str(lv.LooseVersion("1.2.3")) == "1.2.3"
+
+
+def test_repr():
+    assert repr(lv.LooseVersion("1.2.3")) == "LooseVersion ('1.2.3')"
+
+
+@pytest.mark.skipif(sys.version_info < (3,), reason="Needs py3.x")
+@pytest.mark.parametrize(
+    "op",
+    [
+        operator.lt,
+        operator.le,
+        operator.gt,
+        operator.ge,
+    ],
+)
+def test_invalid_comparison(op):
+    v1 = lv.LooseVersion("1")
+    v2 = 1
+    with pytest.raises(TypeError):
+        op(v1, v2)
+
+
+def test_equality_comparison():
+    assert lv.LooseVersion("1") != 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Trying out new permission as a mantainer. I can find nothing to change in the code, it's perfect, so I added some test coverage. This change will not require a tag or a publish, of course.

As long as the package 'advertises' support for py2, i.e. by having a wheel tagged as [`-py2.py3-none-any.whl`](https://pypi.org/project/looseversion/1.3.0/#files) on PyPI, the CI tests ought to run on py2 aswell.

I do not know how to get containerized 2.7 test into the tox matrix (do you?), so I've added it as a separate task in the GHA workflows instead.