### PR TITLE
chore: Test on py313, updating CI infrastructure

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -12,24 +12,13 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python: [3]
+    permissions:
+      attestations: write
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@v5
+    - uses: hynek/build-and-inspect-python-package@v2
       with:
-        python-version: ${{ matrix.python }}
-    - name: Build package
-      run: pipx run build
-    - name: Check package metadata
-      run: pipx run twine check dist/*
-    - name: Save packages
-      uses: actions/upload-artifact@v4
-      with:
-        name: dist
-        path: dist/
+        attest-build-provenance-github: ${{ github.event_name != 'pull_request' }}
 
   test:
     runs-on: ubuntu-latest
@@ -76,14 +65,14 @@ jobs:
     needs: [build, test]
     runs-on: ubuntu-latest
     permissions:
-      # IMPORTANT: this permission is mandatory for trusted publishing
+      attestations: write
       id-token: write
     steps:
-    - name: Load packages
+    - name: Download packages built by build-and-inspect-python-package
       uses: actions/download-artifact@v4
       with:
-        name: dist
-        path: dist/
+        name: Packages
+        path: dist
     - name: Test PyPI upload
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -44,6 +44,8 @@ jobs:
           - "3.12"
           - "3.13"
           - "pypy-3.7"
+          - "pypy-3.9"
+          - "pypy-3.10"
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -37,13 +37,18 @@ jobs:
           - "pypy-3.10"
     steps:
     - uses: actions/checkout@v4
+    - name: Install the latest version of uv
+      uses: astral-sh/setup-uv@v4
     - name: Set up Python ${{ matrix.python }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python }}
         allow-prereleases: true
     - name: Install tox
-      run: pip install --upgrade pip tox tox-gh-actions
+      run: |
+        # Use tox-uv if available, fall back to regular tox (py<3.8)
+        uv tool install --with=tox-uv --with=tox-gh-actions tox \
+          || uv tool install --with=tox-gh-actions tox
     - name: Show tox config
       run: tox c
     - name: Test

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -53,6 +53,8 @@ jobs:
         allow-prereleases: true
     - name: Install tox
       run: pip install --upgrade pip tox tox-gh-actions
+    - name: Show tox config
+      run: tox c
     - name: Test
       run: tox
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -42,6 +42,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
           - "pypy-3.7"
     steps:
     - uses: actions/checkout@v4

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## Releases
 
+### Upcoming (To be determined)
+
+- 2025.01.02
+  - Test on Python 3.13, updating CI infrastructure.
+
 ### 1.3.0 (5 Jul 2023)
 
 - 2023.07.05

--- a/src/looseversion/__init__.py
+++ b/src/looseversion/__init__.py
@@ -16,6 +16,7 @@ Every version number class implements the following interface:
     of the same class or a string (which will be parsed to an instance
     of the same class, thus must follow the same rules)
 """
+
 import re
 import sys
 
@@ -228,6 +229,7 @@ class LooseVersion2(LooseVersion):
     and int always resulted in the string being "greater". In Python 3, this produced
     a TypeError.
     """
+
     def parse(self, vstring):
         # I've given up on thinking I can reconstruct the version string
         # from the parsed tuple -- so I just store the string here for

--- a/tests.py
+++ b/tests.py
@@ -10,7 +10,7 @@ have_distutils = True
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
     try:
-        from distutils import version as dv
+        from distutils import version as dv  # type: ignore[import-not-found]
     except ImportError:
         have_distutils = False
 

--- a/tox.ini
+++ b/tox.ini
@@ -19,5 +19,5 @@ commands =
 
 [gh-actions]
 python =
-  pypy-3.7: py
+  pypy-3: py
   3: py, type

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = true
-envlist = py{36,37,38,39,310,311,312,py3}, type
+envlist = py,type
 skip_missing_interpreters = True
 
 [testenv]
@@ -19,11 +19,5 @@ commands =
 
 [gh-actions]
 python =
-  3.6: py36
-  3.7: py37
-  3.8: py38
-  3.9: py39
-  3.10: py310
-  3.11: py311, type
-  3.12: py312
-  pypy-3.7: pypy3
+  pypy-3.7: py
+  3: py, type


### PR DESCRIPTION
Just keeping things exercised and conforming CI a bit to other packages I maintain, primarily using uv/tox-uv where possible.

This should enable attestations, so it might be worth exercising the release process, but there's no change to the code.